### PR TITLE
Resolve #76

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -5,7 +5,7 @@
 #               apple-ibridge drivers, respectively.
 
 pkgbase="linux-t2"
-_pkgver=6.16.1
+_pkgver=6.17
 pkgver=${_pkgver}
 _srcname=linux-${_pkgver}
 pkgrel=1


### PR DESCRIPTION
Patches were updated to 6.17 which fail on 6.16.1, updated PKGBUILD to use 6.17

<img width="1437" height="561" alt="image" src="https://github.com/user-attachments/assets/2699b522-a3aa-4949-b6c1-d34c69a9daf0" />
